### PR TITLE
Returns correct session name when used custom name and call `Session::getName()` before session open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- Fix #45: Returns correct session name when used custom name and call `Session::getName()` before session open (@vjik)
 
 ## 1.1.0 October 28, 2022
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -125,6 +125,7 @@ final class Session implements SessionInterface
 
     public function getName(): string
     {
+        $this->open();
         return session_name();
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -9,6 +9,10 @@ use Throwable;
 
 /**
  * Session provides session data management and the related configurations.
+ *
+ * @psalm-type SessionOptions = array{
+ *     name?: string,
+ * }&array<string,mixed>
  */
 final class Session implements SessionInterface
 {
@@ -23,11 +27,17 @@ final class Session implements SessionInterface
     ];
 
     private ?string $sessionId = null;
+
+    /**
+     * @psalm-var SessionOptions
+     */
     private array $options;
 
     /**
      * @param array $options Session options. See {@link https://www.php.net/manual/en/session.configuration.php}.
      * @param SessionHandlerInterface|null $handler Session handler. If not specified, default PHP handler is used.
+     *
+     * @psalm-param SessionOptions $options
      */
     public function __construct(array $options = [], SessionHandlerInterface $handler = null)
     {
@@ -125,8 +135,11 @@ final class Session implements SessionInterface
 
     public function getName(): string
     {
-        $this->open();
-        return session_name();
+        if ($this->isActive()) {
+            return session_name();
+        }
+
+        return $this->options['name'] ?? session_name();
     }
 
     public function all(): array

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -202,4 +202,11 @@ final class SessionTest extends TestCase
         $session->open();
         $session->regenerateId();
     }
+
+    public function testCustomSessionName(): void
+    {
+        $session = $this->getSession(['name' => 'test']);
+
+        $this->assertSame('test', $session->getName());
+    }
 }

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -203,10 +203,40 @@ final class SessionTest extends TestCase
         $session->regenerateId();
     }
 
-    public function testCustomSessionName(): void
+    public function dataSessionNameBeforeOpen(): array
     {
-        $session = $this->getSession(['name' => 'test']);
+        return [
+            ['PHPSESSID', []],
+            ['test', ['name' => 'test']],
+        ];
+    }
 
-        $this->assertSame('test', $session->getName());
+    /**
+     * @dataProvider dataSessionNameBeforeOpen
+     */
+    public function testSessionNameBeforeOpen(string $expectedName, array $options): void
+    {
+        $session = $this->getSession($options);
+
+        $this->assertSame($expectedName, $session->getName());
+    }
+
+    public function dataSessionNameAfterOpen(): array
+    {
+        return [
+            ['PHPSESSID', []],
+            ['test', ['name' => 'test']],
+        ];
+    }
+
+    /**
+     * @dataProvider dataSessionNameAfterOpen
+     */
+    public function testSessionNameAfterOpen(string $expectedName, array $options): void
+    {
+        $session = $this->getSession($options);
+        $session->open();
+
+        $this->assertSame($expectedName, $session->getName());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #45
