### PR TITLE
Fix session in long-running apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.1 under development
 
-- no changes in this release.
+- Bug #61: Reset session between requests in long-running applications (@viktorprogger, @roxblnfk)
 
 ## 2.1.0 May 02, 2024
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -92,6 +92,8 @@ final class Session implements SessionInterface
 
         if ($this->sessionId !== null) {
             session_id($this->sessionId);
+        } else {
+            session_id(bin2hex(random_bytes(16)));
         }
 
         try {

--- a/src/Session.php
+++ b/src/Session.php
@@ -93,7 +93,7 @@ final class Session implements SessionInterface
         if ($this->sessionId !== null) {
             session_id($this->sessionId);
         } else {
-            session_id(bin2hex(random_bytes(16)));
+            session_id(session_create_id());
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | ❌

Fixes a bug for long-running applications: session is not resetted between requests. Session ids are UTF-safe, as this may be critical for some session handlers.