### PR TITLE
Remove `sid_length` and `sid_bits_per_character` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Yii Session Change Log
 
-## 2.1.1 under development
+## 3.0.0 under development
 
 - Chg #66: Remove `sid_length` and `sid_bits_per_character` options (@vjik)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.1 under development
 
-- no changes in this release.
+- Chg #66: Remove `sid_length` and `sid_bits_per_character` options (@vjik)
 
 ## 2.1.0 May 02, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,15 @@
+# Upgrading Instructions for Yii Session
+
+This file contains the upgrade notes for the Yii Session.
+These notes highlight changes that could break your application when you upgrade it from one major version to another.
+
+## 3.0.0
+
+`sid_length` and `sid_bits_per_character` settings are removed from default session options, because they are marked as
+deprecated in PHP 8.4. In PHP default values of these settings are different. So, if you don't set these settings
+explicitly, values will change after Yii Session update:
+
+- `sid_length` from `48` to `32`;
+- `sid_bits_per_character` from `5` to `4`.
+
+Keep this in mind in your application.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,5 +11,3 @@ explicitly, values will change after Yii Session update:
 
 - `sid_length` from `48` to `32`;
 - `sid_bits_per_character` from `5` to `4`.
-
-Keep this in mind in your application.

--- a/src/Session.php
+++ b/src/Session.php
@@ -21,8 +21,6 @@ final class Session implements SessionInterface
         'use_only_cookies' => 1,
         'cookie_httponly' => 1,
         'use_strict_mode' => 1,
-        'sid_bits_per_character' => 5,
-        'sid_length' => 48,
         'cookie_samesite' => 'Lax',
     ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

See [RFC](https://wiki.php.net/rfc/deprecations_php_8_4#sessionsid_length_and_sessionsid_bits_per_character).

In PHP 8.4 these options are deprecated.

