### PR TITLE
Open session in `Session::regenerateId()` if it is not active yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 3.0.2 under development
 
-- Chg #81: Add explicit use imports for classes and constants (@vjik)
+- Enh #81: Add explicit use imports for classes and constants (@vjik)
+- Bug #85: Open session in `Session::regenerateId()` if it is not active yet (@vjik)
 
 ## 3.0.1 December 17, 2025
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -117,17 +117,17 @@ final class Session implements SessionInterface
 
     public function regenerateId(): void
     {
-        if ($this->isActive()) {
-            try {
-                if (session_regenerate_id(true)) {
-                    /**
-                     * @var string Without `id` parameter `session_id()` always returns string.
-                     */
-                    $this->sessionId = session_id();
-                }
-            } catch (Throwable $e) {
-                throw new SessionException('Failed to regenerate ID.', (int) $e->getCode(), $e);
+        $this->open();
+
+        try {
+            if (session_regenerate_id(true)) {
+                /**
+                 * @var string Without `id` parameter `session_id()` always returns string.
+                 */
+                $this->sessionId = session_id();
             }
+        } catch (Throwable $e) {
+            throw new SessionException('Failed to regenerate ID.', (int) $e->getCode(), $e);
         }
     }
 

--- a/src/SessionInterface.php
+++ b/src/SessionInterface.php
@@ -54,6 +54,7 @@ interface SessionInterface
 
     /**
      * Regenerate session ID keeping data.
+     * Opens the session first if it is not active yet.
      */
     public function regenerateId(): void;
 

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -82,6 +82,17 @@ final class SessionTest extends TestCase
         self::assertNotEquals($id, $session->getId());
     }
 
+    public function testRegenerateIdOpensInactiveSession(): void
+    {
+        $session = $this->getSession();
+        self::assertFalse($session->isActive());
+
+        $session->regenerateId();
+
+        self::assertTrue($session->isActive());
+        self::assertNotNull($session->getId());
+    }
+
     public function testDiscard(): void
     {
         $session = $this->getSession();

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -85,12 +85,15 @@ final class SessionTest extends TestCase
     public function testRegenerateIdOpensInactiveSession(): void
     {
         $session = $this->getSession();
+        $session->open();
+        $id = $session->getId();
+        $session->close();
         self::assertFalse($session->isActive());
 
         $session->regenerateId();
 
         self::assertTrue($session->isActive());
-        self::assertNotNull($session->getId());
+        self::assertNotEquals($id, $session->getId());
     }
 
     public function testDiscard(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
Fix https://github.com/yiisoft/user/issues/124
